### PR TITLE
sidebar.html: fix home link

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -2,7 +2,7 @@
   <div class="container sidebar">
     <div class="sidebar-about">
       <h1>
-        <a href="{{ site.baseurl }}">
+        <a href="{{ site.baseurl }}/">
           {{ site.title }}
         </a>
       </h1>


### PR DESCRIPTION
Fixed the `Programming for Biologists` link by adding a `/` similar to `Home`.
_config.html::site.base.url  = /datacarp-semester-biology

I think this breaks the `sidebar-nav` class. It's minor, but the `Home` link does not bold when you are on the homepage as it does for the others. This is a minor glitch for how many `/` we'd have to delete throughout the rest of the site. Also, it seems like if you don't mind not having that feature, we can have a lot more flexibility with how we structure the sidebar. 