### PR TITLE
_config.yml: update title

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ highlighter:      pygments
 permalink:        pretty
 
 # Setup
-title:            Programming for Biologists
+title:            Data Carpentry -for- Biologists
 tagline:          'A Jekyll theme'
 description:      'Teaching biologists the tools they need to use computers to do cool science'
 url:              http://www.progbio.org


### PR DESCRIPTION
(As per #103)

I chose to add '-' around the 'for' for visual appeal. I don't feel strongly about it though. There might be benefits to keeping it simply 'Data Carpentry for Biologists'. The two options I considered are:

Data
Carpentry
-for- Biologists

OR

Data
Carpentry for
Biologists
